### PR TITLE
fix(ci): move workflow permissions to job level scope

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -4,12 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5


### PR DESCRIPTION
This PR moves GitHub Actions permissions from workflow level to job level scope for better security.

## Changes
- Move permissions from workflow level to labeler job level  
- Ensures proper permission scoping for GitHub Actions
- Improves security by limiting permissions to specific jobs

## Files Changed
- `.github/workflows/pr-labeler.yaml` - Restructured permissions scope

🤖 Generated with [Claude Code](https://claude.ai/code)